### PR TITLE
NVIcheckmate v0.3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: NVIcheckmate
 Title: Extension of checkmate with argument checking adapted for NVIverse
-Version: 0.3.2
-Date: 2021-09-28
+Version: 0.3.3
+Date: 2021-11-04
 Authors@R: 
     c(person(given = "Petter",
            family = "Hopp",

--- a/NEWS
+++ b/NEWS
@@ -1,22 +1,29 @@
+NVIcheckmate 0.3.3 - (2021-11-04)
+
+Bug fixes:
+
+  - assert_choices_character and assert_subset_character now accepts argument ignore.case = FALSE.
+  
+  
 NVIcheckmate 0.3.2 - (2021-09-28)
 
 Bug fixes:
 
-  - check_non_null don't give a warning when input is a vector or data frame. Only check for class == NULL
+  - check_non_null don't give a warning when input is a vector or data frame. Only check for class == NULL.
   
   
 NVIcheckmate 0.3.1 - (2021-09-27)
 
 Bug fixes:
 
-  - input to check_non_missing and assert_non_missing check corrected to list, not vector
+  - input to check_non_missing and assert_non_missing check corrected to list, not vector.
   
   
 NVIcheckmate 0.3.0 - (2021-09-16)
 
 New features:
 
-  - check_non_missing and assert_non_missing check if at least one of two or more arguments are non_missing
+  - check_non_missing and assert_non_missing check if at least one of two or more arguments are non_missing.
   
   
 NVIcheckmate 0.2.0 - (2021-09-05)

--- a/R/check_choice_character.R
+++ b/R/check_choice_character.R
@@ -33,6 +33,9 @@ check_choice_character <- function(x, choices, null.ok = FALSE, ignore.case = FA
   if (isTRUE(ignore.case)) { 
     xx <- tolower(x)
     choicesx <- tolower(choices)
+  } else {
+    xx <- x
+    choicesx <- choices
   }
   res <- checkmate::check_choice(x = xx, choices = choicesx , null.ok = null.ok, fmatch = fmatch)
   if (!isTRUE(res) & isTRUE(ignore.case)) {

--- a/R/check_subset_character.R
+++ b/R/check_subset_character.R
@@ -43,6 +43,9 @@ check_subset_character <- function(x, choices, ignore.case = FALSE, empty.ok = T
   if (isTRUE(ignore.case)) { 
     xx <- tolower(x)
     choicesx <- tolower(choices)
+  } else {
+    xx <- x
+    choicesx <- choices
   }
   res <- checkmate::check_subset(x = xx, choices = choicesx , empty.ok = empty.ok, fmatch = fmatch)
   if (!isTRUE(res) & isTRUE(ignore.case)) {


### PR DESCRIPTION
fix: assert_choice_character and assert_subset_character now accespts ignore.case = FALSE